### PR TITLE
Get rid of "Chrome is being controlled..." banner in recent Chromium versions

### DIFF
--- a/bord/bord.py
+++ b/bord/bord.py
@@ -41,6 +41,7 @@ class Bord:
             logLevel="INFO",
             autoclose=False,
             args=["--kiosk", "--disable-infobars"],
+            ignoreDefaultArgs=["--enable-automation"],
         )
         if self.config.executable_path is not None:
             browser_kwargs["executablePath"] = self.config.executable_path


### PR DESCRIPTION
Closes #8
See https://github.com/puppeteer/puppeteer/issues/2070#issuecomment-525556114